### PR TITLE
Fix: connection database was not set properly on startup

### DIFF
--- a/dbsqlcli/sqlexecute.py
+++ b/dbsqlcli/sqlexecute.py
@@ -17,16 +17,16 @@ class SQLExecute(object):
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token
-        self.database = database
+        self.database = database or 'default'
 
-        self.connect()
+        self.connect(database=self.database)
 
     def connect(self, database=None):
         conn = dbsql.connect(
             server_hostname=self.hostname,
             http_path=self.http_path,
             access_token=self.access_token,
-            schema=database or 'default'
+            schema=database
         )
 
         self.database = database or self.database


### PR DESCRIPTION
The fixes in #2 missed the case where a schema other than `default` was passed-in during start. This change makes it so the command line argument is properly set to the current database.

## Verification


### Reproduction
1. Start dbsqli with a non-default database (`lego` for example)
2. run `SHOW TABLES` or `\dt`
3. Output shows the list of tables for the `default` schema

After this fix, step 3 shows the list of tables for the startup db (`lego`).

### Screenshots

#### Before
<img width="1047" alt="CleanShot 2022-03-30 at 09 17 45@2x" src="https://user-images.githubusercontent.com/17067911/160856557-d86880f0-f9de-4d0a-a77a-da578c817193.png">

#### After

<img width="1047" alt="CleanShot 2022-03-30 at 09 18 10@2x" src="https://user-images.githubusercontent.com/17067911/160856632-40b2f74f-ce87-48a9-bedf-8df154879f92.png">

