### PR TITLE
Remove the download command

### DIFF
--- a/dbsqlcli/packages/special/iocommands.py
+++ b/dbsqlcli/packages/special/iocommands.py
@@ -524,15 +524,3 @@ def watch_query(arg, **kwargs):
             return
         finally:
             set_pager_enabled(old_pager_enabled)
-
-
-@special_command(
-    "download", "download", "Download results from last query.", arg_type=NO_QUERY
-)
-def download():
-    if OUTPUT_LOCATION is None:
-        return [(None, None, None, "No OUTPUT_LOCATION from last query")]
-    else:
-        aws_s3_command = f"aws s3 cp {OUTPUT_LOCATION} /tmp/"
-        click.echo(f"Running: {aws_s3_command}")
-        return execute_system_command(aws_s3_command)


### PR DESCRIPTION
## Description

The `download` command originally came from `athena-cli` which could store cached results in S3. Databricks SQL does not store results in this way so the command is not applicable.

## Related Tickets & Documents

Closes #15 