### PR TITLE
Remove reference to Slack channel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ Options:
 
 # Contributions
 
-During its internal release, please report issues in the #dbsqlcli Slack channel.
-
 We use [Poetry](https://python-poetry.org/docs/) for development. Follow the instructions to install Poetry on your system. 
 
 1. Clone this repository


### PR DESCRIPTION
As we getting closer to opening the source code, figured this is no longer needed.