### PR TITLE
Change the version in pyproject.toml to be semantically correct.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-cli"
-version = "0.1.x"
+version = "0.0.0"
 description = "A DBCLI client for Databricks SQL"
 authors = ["Databricks SQL CLI Maintainers <dbsqlcli-maintainers@databricks.com>"]
 packages = [{include = "dbsqlcli"}]


### PR DESCRIPTION
The current string (`0.1.x`) makes commands like `poetry install` to fail. Because the version is irrelevant to our release processes, I updated it to be `0.0.0`.

We should consider keeping it up to date, but for now this should be enough to make the commands work.