### PR TITLE
Remove sqlparse.compat import

### DIFF
--- a/dbsqlcli/packages/completion_engine.py
+++ b/dbsqlcli/packages/completion_engine.py
@@ -4,7 +4,6 @@ import sqlparse
 import logging
 from collections import namedtuple
 from sqlparse.sql import Comparison, Identifier, Where
-from sqlparse.compat import text_type
 
 from dbsqlcli.packages.parseutils import last_word, extract_tables, find_prev_keyword
 from dbsqlcli.packages.special import parse_special_command
@@ -78,7 +77,7 @@ def suggest_type(full_text, text_before_cursor):
         stmt_start, stmt_end = 0, 0
 
         for statement in parsed:
-            stmt_len = len(text_type(statement))
+            stmt_len = len(str(statement))
             stmt_start, stmt_end = stmt_end, stmt_end + stmt_len
 
             if stmt_end >= current_pos:


### PR DESCRIPTION
sqlparse do no longer have sqlparse.compat. It was removed in version 0.4. It is missing from GitHub source and sqlparse-0.4.2.tar.gz from PyPI. But it exist in sqlparse-0.4.2-py3-none-any.whl from PyPi for some strang reasone.

Since databricks-sql-cli import 'text_type' form sqlparse.compat it will faile if you install sqlparse in any other way other than wheel.

sqlparse was remooved in the following commit:
https://github.com/andialbrecht/sqlparse/commit/3e3892f939031d58d98275ce8a237689225d299a 'text_type' was replaced with 'str' so we do the same in databricks-sql-cli.