### PR TITLE
Add Catalog handling in database name

### DIFF
--- a/dbsqlcli/dbsqlclirc
+++ b/dbsqlcli/dbsqlclirc
@@ -43,6 +43,7 @@ syntax_style = default
 key_bindings = emacs
 
 # DBSQL prompt
+# \c - Catalog name
 # \d - Database name
 # \h - Hostname
 # \D - The full current date
@@ -51,7 +52,7 @@ key_bindings = emacs
 # \P - AM/PM
 # \R - The current time, in 24-hour military time (0–23)
 # \s - Seconds of the current time
-prompt = '\h:\d> '
+prompt = '\h:\c.\d> '
 prompt_continuation = '-> '
 
 # enable pager on startup

--- a/dbsqlcli/main.py
+++ b/dbsqlcli/main.py
@@ -704,6 +704,7 @@ def cli(
     Examples:
       - dbsqlcli
       - dbsqlcli my_database
+      - dbsqlcli my_catalog.my_database
     """
     if (clirc == DBSQLCLIRC) and (not os.path.exists(os.path.expanduser(clirc))):
         err_msg = (

--- a/dbsqlcli/main.py
+++ b/dbsqlcli/main.py
@@ -213,7 +213,7 @@ For more details about the error, you can check the log file: %s""" % (
             None,
             None,
             None,
-            'You are now connected to database "%s"' % self.sqlexecute.database,
+            'You are now connected to database "%s.%s"' % (self.sqlexecute.catalog, self.sqlexecute.database),
         )
 
     def change_prompt_format(self, arg, **_):
@@ -599,6 +599,7 @@ For more details about the error, you can check the log file: %s""" % (
         string = string.replace(
             "\\h", sqlexecute.hostname.replace(".cloud.databricks.com", "")
         )
+        string = string.replace("\\c", sqlexecute.catalog or "(none)")
         string = string.replace("\\d", sqlexecute.database or "(none)")
         string = string.replace("\\n", "\n")
         string = string.replace("\\D", now.strftime("%a %b %d %H:%M:%S %Y"))

--- a/dbsqlcli/main.py
+++ b/dbsqlcli/main.py
@@ -213,7 +213,8 @@ For more details about the error, you can check the log file: %s""" % (
             None,
             None,
             None,
-            'You are now connected to database "%s.%s"' % (self.sqlexecute.catalog, self.sqlexecute.database),
+            'You are now connected to database "%s.%s"'
+            % (self.sqlexecute.catalog, self.sqlexecute.database),
         )
 
     def change_prompt_format(self, arg, **_):

--- a/dbsqlcli/packages/special/dbcommands.py
+++ b/dbsqlcli/packages/special/dbcommands.py
@@ -37,9 +37,8 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
     "\\l", "\\l", "List databases.", arg_type=RAW_QUERY, case_sensitive=True
 )
 def list_databases(cur, **_):
-    _databases = cur.schemas().fetchall()
-    if _databases:
-        headers = [x[0] for x in _databases]
-        return [(None, _databases, headers, "")]
-    else:
-        return [(None, None, None, "")]
+    databases = cur.schemas().fetchall()
+    if databases:
+        headers = [field.title().removeprefix("Table_") for field in databases[0].__fields__]
+        return [(None, databases, headers, "")]
+    return [(None, None, None, "")]

--- a/dbsqlcli/packages/special/dbcommands.py
+++ b/dbsqlcli/packages/special/dbcommands.py
@@ -39,6 +39,8 @@ def list_tables(cur, arg=None, arg_type=PARSED_QUERY, verbose=False):
 def list_databases(cur, **_):
     databases = cur.schemas().fetchall()
     if databases:
-        headers = [field.title().removeprefix("Table_") for field in databases[0].__fields__]
+        headers = [
+            field.title().removeprefix("Table_") for field in databases[0].__fields__
+        ]
         return [(None, databases, headers, "")]
     return [(None, None, None, "")]

--- a/dbsqlcli/sqlexecute.py
+++ b/dbsqlcli/sqlexecute.py
@@ -42,7 +42,12 @@ class SQLExecute(object):
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token
+        self.auth_type = auth_type
+        self._set_catalog_database(database)
+        self.connect()
 
+    def _set_catalog_database(self, database):
+        """Sets the catalog and database name if a single dot is supplied"""
         if database.count(".") == 1:
             component = database.split(".")
             self.catalog = component[0]
@@ -51,19 +56,11 @@ class SQLExecute(object):
             self.catalog = "hive_metastore"
             self.database = database
 
-        self.auth_type = auth_type
-
-        self.connect(database=self.database)
-
     def connect(self, database=None):
         self.close_connection()
 
-        if database and database.count(".") == 1:
-            component = database.split(".")
-            self.catalog = component[0]
-            self.database = component[1]
-        elif database:
-            self.database = database
+        if database:
+            self._set_catalog_database(database)
 
         oauth_params = {}
         if self.auth_type == AuthType.DATABRICKS_OAUTH.value:

--- a/dbsqlcli/sqlexecute.py
+++ b/dbsqlcli/sqlexecute.py
@@ -38,7 +38,9 @@ oauth_token_cache = OAuthPersistenceCache()
 class SQLExecute(object):
     DATABASES_QUERY = "SHOW DATABASES"
 
-    def __init__(self, hostname, http_path, access_token, database= "default", auth_type=None):
+    def __init__(
+        self, hostname, http_path, access_token, database="default", auth_type=None
+    ):
         self.hostname = hostname
         self.http_path = http_path
         self.access_token = access_token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sql-cli"
-version = "0.1.x"
+version = "0.1.5"
 description = "A DBCLI client for Databricks SQL"
 authors = ["Databricks SQL CLI Maintainers <dbsqlcli-maintainers@databricks.com>"]
 packages = [{include = "dbsqlcli"}]


### PR DESCRIPTION
The current setup doesn't allow for easy use of Catalogs from the Hive Metastore, and the Unity Catalog.  This request adds the functionality so that catalogs can be selected.

The default catalog is `hive_metastore` when selecting a database with no period.   (eg, `\u default`)  If one period is given, it is assumed the format is `<catalog>.<database>`.  This allows for easy selection of the catalog without to much complication.   (eg, `\u main.default`)

Some addition minor updates/fixes on top of this:
1. The list_databases method used by `\l`was not returning the headers properly, but rather a database and catalog.
2. A method called `reconnect` on the SQLExecute was made redundant by the method `connect` which did the same thing.