### PR TITLE
fix: return auth_type even if credentials are not in config

### DIFF
--- a/dbsqlcli/main.py
+++ b/dbsqlcli/main.py
@@ -64,7 +64,7 @@ def apply_credentials_from_cfg(hostname, http_path, access_token, auth_type, cfg
     """
 
     if not cfg.get("credentials"):
-        return hostname, http_path, access_token
+        return hostname, http_path, access_token, auth_type
 
     hostname = hostname or cfg.get("credentials", {}).get("host_name")
     http_path = http_path or cfg.get("credentials", {}).get("http_path")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -59,3 +59,14 @@ def test_blended_credentials_are_used():
     assert http_path == HTTP_PATH
     assert access_token == "dapi_configRandomAccessKey"
     assert auth_type == AuthType.DATABRICKS_OAUTH.value
+
+
+def test_passthrough_with_empty_config():
+    host_name, http_path, access_token, auth_type = apply_credentials_from_cfg(
+        HOST_NAME, HTTP_PATH, ACCESS_TOKEN, AuthType.DATABRICKS_OAUTH.value, {}
+    )
+
+    assert host_name == HOST_NAME
+    assert http_path == HTTP_PATH
+    assert access_token == ACCESS_TOKEN
+    assert auth_type == AuthType.DATABRICKS_OAUTH.value


### PR DESCRIPTION
Change `dbsqlcli.main.apply_credentials_from_cfg` to return 4 values even if `not cfg.get("credentials")` is true.

This is so that the CLI can be used only with environment variables.

- Fixes <https://github.com/databricks/databricks-sql-cli/issues/46>